### PR TITLE
fix: Add vercel.json for client-side routing support

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION

The vercel.json configuration tells Vercel to redirect all routes ((.*)) to /index.html,
which then lets React Router handle the routing on the client side.